### PR TITLE
feat: Add localize Jupyter(scipy-notebook) environment for myself

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# jupyter/scipy-notebook
+# https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook
+FROM quay.io/jupyter/scipy-notebook:python-3.11
+
+USER root
+
+RUN set -ex \
+	&& apt update \
+	&& apt upgrade -y \
+	&& apt install -y tzdata \
+	&& apt autoclean -y \
+	&& apt autoremove -y \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Set time zone
+ENV TZ=Asia/Tokyo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+USER jovyan
+
+RUN pip install --upgrade pip wheel setuptools
+RUN conda update --all -y \
+	&& conda clean -i -t -y

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     volumes:
       - ./work:/home/jovyan/work
     environment:
-      # TODO NOT need for latest jupyter image??
       - JUPYTER_ENABLE_LAB=yes
     tty: true
     stdin_open: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+name: jupyter-my-local
 services:
   jupyterlab:
     container_name: jupyter-scipy-local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   jupyterlab:
     container_name: jupyter-scipy-local
-    image: quay.io/jupyter/scipy-notebook:python-3.11
+    build:
+      context: .
     command: start-notebook.py --ServerApp.root_dir=/home/jovyan/work --IdentityProvider.token=''
     ports:
       - "8888:8888"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  jupyterlab:
+    container_name: jupyter-scipy-local
+    image: quay.io/jupyter/scipy-notebook:python-3.11
+    command: start-notebook.py --ServerApp.root_dir=/home/jovyan/work --IdentityProvider.token=''
+    ports:
+      - "8888:8888"
+    volumes:
+      - ./work:/home/jovyan/work
+    environment:
+      # TODO NOT need for latest jupyter image??
+      - JUPYTER_ENABLE_LAB=yes
+    tty: true
+    stdin_open: true


### PR DESCRIPTION
## Summary

- This is support for my localize Jupyter environment container.

## Description

- Base image comes from official quay repository.
  - I choose `jupyter/scipy-notebook` because just need bare minimum, without deep learning for now.
  - See: [Selecting an Image — Docker Stacks documentation > jupyter/scipy-notebook](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook)
- Some revisions to the official image.
  - Setting time zone.
  - apt upgrade and clean
  - pkg(pip related) update without pkg linked to conda
  - pkg(conda related) update and clean cache
- This should be used for only local, thus I don't set password for Jupyter connections.
