### PR TITLE
fix: Modify to update conda in the base environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,6 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 USER jovyan
 
 RUN pip install --upgrade pip wheel setuptools
-RUN conda update --all -y \
+RUN conda update -n base -c conda-forge conda \
+	&& conda update --all -y \
 	&& conda clean -i -t -y


### PR DESCRIPTION
## Summary

- Updated the procedure for updating Conda packages.

## Description

- This ensures that Conda itself in the base environment is updated first, followed by updating all packages.
