### PR TITLE
feat: Japanese localization support for Matplotlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN conda update -n base -c conda-forge conda \
 	&& conda clean -i -t -y
 
 # Not japanize-matplotlib but matplotlib-fontja
-# because japanize-matplotlib does not work with Python 3.12 or later and `conda install` does not work even with Python 3.11 or before.
+# because japanize-matplotlib does not work with Python 3.12 or later and `conda install japanize-matplotlib` does not work even with Python 3.11 or before.
 # https://github.com/ciffelia/matplotlib-fontja
 RUN conda install conda-forge::matplotlib-fontja

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,8 @@ RUN pip install --upgrade pip wheel setuptools
 RUN conda update -n base -c conda-forge conda \
 	&& conda update --all -y \
 	&& conda clean -i -t -y
+
+# Not japanize-matplotlib but matplotlib-fontja
+# because japanize-matplotlib does not work with Python 3.12 or later and `conda install` does not work even with Python 3.11 or before.
+# https://github.com/ciffelia/matplotlib-fontja
+RUN conda install conda-forge::matplotlib-fontja


### PR DESCRIPTION
## Purpose / Background

- The fonts in Matplotlib are not Japanese-compatible by default, so this'll fix that.

## Changes

- Added conda install NOT japanize-matplotlib but matplotlib-fontja.
  - japanize-matplotlib does not work with Python 3.12 or later and `conda install japanize-matplotlib` does not work even with Python 3.11 or before.

## Additional Notes

- See: [ciffelia/matplotlib\-fontja: install & import するだけで matplotlib を日本語表示対応させる](https://github.com/ciffelia/matplotlib-fontja)
